### PR TITLE
Fix errors when using Homebrew asdf

### DIFF
--- a/hexdocs.sh
+++ b/hexdocs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+if [[ -f ~/.asdf/asdf.sh ]]; then
+	source ~/.asdf/asdf.sh
+elif [[ "$(command -v brew)" != "" && -f "$(brew --prefix asdf)/libexec/asdf.sh" ]]; then
+	source "$(brew --prefix asdf)/libexec/asdf.sh"
+elif [[ "$(command -v elixir)" == "" ]]; then
+	echo '{"items":[{"title": "Error","subtitle":"Could not find existing Elixir installation"}]}'
+	exit 1
+fi
+
+elixir hexdocs.exs "$1"

--- a/info.plist
+++ b/info.plist
@@ -79,7 +79,15 @@
 				<key>runningsubtext</key>
 				<string>Loading...</string>
 				<key>script</key>
-				<string>source ~/.asdf/asdf.sh
+				<string>export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+if [[ -f ~/.asdf/asdf.sh ]]; then
+	source ~/.asdf/asdf.sh
+elif [[ $(command -v brew) != "" &amp;&amp; -f $(brew --prefix asdf)/libexec/asdf.sh ]]; then
+	source $(brew --prefix asdf)/libexec/asdf.sh
+elif [[ $(command -v elixir) == "" ]]; then
+	echo "{\"items\":[{\"title\": \"Error\",\"subtitle\":\"Could not find existing Elixir installation\"}]}"
+	exit 1
+fi
 elixir hexdocs.exs "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>

--- a/info.plist
+++ b/info.plist
@@ -79,16 +79,7 @@
 				<key>runningsubtext</key>
 				<string>Loading...</string>
 				<key>script</key>
-				<string>export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
-if [[ -f ~/.asdf/asdf.sh ]]; then
-	source ~/.asdf/asdf.sh
-elif [[ $(command -v brew) != "" &amp;&amp; -f $(brew --prefix asdf)/libexec/asdf.sh ]]; then
-	source $(brew --prefix asdf)/libexec/asdf.sh
-elif [[ $(command -v elixir) == "" ]]; then
-	echo "{\"items\":[{\"title\": \"Error\",\"subtitle\":\"Could not find existing Elixir installation\"}]}"
-	exit 1
-fi
-elixir hexdocs.exs "$1"</string>
+				<string>./hexdocs.sh "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>


### PR DESCRIPTION
(Following up on https://twitter.com/davydog187/status/1659905371866120194)

This (hopefully) fixes the issue outlined in the above tweet. For me, the problem was caused by using [asdf installed using Homebrew](https://asdf-vm.com/guide/getting-started.html#community-supported-download-methods) instead of the officially-supported git installation method. An official installation places `asdf.sh` in the home directory, but Homebrew requires consulting `brew --prefix asdf`.

So, this PR first checks for an official install, then a Homebrew install, and finally falls back to the system `elixir` binary if one exists (hey, not everybody uses asdf... yet!). Otherwise, an error is displayed so the user can take corrective action (instead of silently failing like it currently does).

As explained in the tweet thread, we're tweaking `$PATH` so Alfred 4 can detect Homebrew. [Alfred 5 adds this automatically](https://www.alfredapp.com/help/workflows/advanced/understanding-scripting-environment/), so we're merely aligning behavior between Alfred 4 & 5 - there should be no "downside" to doing so, but perhaps it would be wise to first check for the existence of `/opt/homebrew/bin` in the `$PATH` just to be clean. (Let me know and I can amend the PR, I just didn't want to get too unwieldy with the shell code! 😅 Alternatively, it could be removed altogether if A4 support isn't in-scope.)

Here's the actual formatted code:

```bash
export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
if [[ -f ~/.asdf/asdf.sh ]]; then
	source ~/.asdf/asdf.sh
elif [[ $(command -v brew) != "" && -f $(brew --prefix asdf)/libexec/asdf.sh ]]; then
	source $(brew --prefix asdf)/libexec/asdf.sh
elif [[ $(command -v elixir) == "" ]];
	echo "{\"items\":[{\"title\": \"Error\",\"subtitle\":\"Could not find existing Elixir installation\"}]}"
	exit 1
fi
elixir hexdocs.exs "$1"
```

One unrelated suggestion: I had a better experience with this plugin after changing "Queue Delay" to "Immediately after each character typed" (open the script filter -> "Run Behavior" button > change "Queue Delay"). I was going to send a PR for that as well, but [hex imposes a 100rpm limit per IP](https://github.com/hexpm/specifications/blob/main/apiary.apib#L37), so perhaps that's best considered if/when caching is added. Or maybe it doesn't matter, 100 a minute is quite a bit 🤔 Figured I'd bring it up at least! (I also liked "Terminate previous script" to prevent old results from flickering in and out, but that's quite subjective - some might prefer having results show up even if stale.)

Phew, I hope this helps a bit. Thanks for the excellent package, I love how simple it is, Elixir is truly wonderful! 😄 